### PR TITLE
✨ [minify-literals] better cssText support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 scripts/dist
 packages/*/dist
 .turbo
+.vscode/settings.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "biomejs.biome"
+    ]
+}

--- a/.vscode/settings.recommend.json
+++ b/.vscode/settings.recommend.json
@@ -1,0 +1,8 @@
+{
+    "[json]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[typescript]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+}

--- a/packages/minify-literals/lib/index.ts
+++ b/packages/minify-literals/lib/index.ts
@@ -210,9 +210,13 @@ export function defaultShouldMinifyCSS(template: Template) {
  */
 export const defaultValidation: Validation = {
 	ensurePlaceholderValid(placeholder) {
-		if (typeof placeholder !== "string" || !placeholder.length) {
-			throw new Error("getPlaceholder() must return a non-empty string");
+		if (typeof placeholder === "string" && placeholder.length > 0) {
+			return;
 		}
+		if (Array.isArray(placeholder) && placeholder.every((ph) => ph.length > 0)) {
+			return;
+		}
+		throw new Error("getPlaceholder() must return a non-empty string | string[]");
 	},
 	ensureHTMLPartsValid(parts, htmlParts) {
 		if (parts.length !== htmlParts.length) {
@@ -291,7 +295,7 @@ export async function minifyHTMLLiterals(source: string, options: Options = {}):
 
 		if (!(minifyHTML || minifyCSS)) return;
 
-		const placeholder = strategy.getPlaceholder(template.parts);
+		const placeholder = strategy.getPlaceholder(template.parts, template.tag);
 		if (validate) {
 			validate.ensurePlaceholderValid(placeholder);
 		}

--- a/packages/minify-literals/lib/strategy.test.ts
+++ b/packages/minify-literals/lib/strategy.test.ts
@@ -26,10 +26,12 @@ describe("strategy", () => {
 			});
 
 			it('should append "_" if placeholder exists in templates', () => {
-				const regularPlaceholder = defaultStrategy.getPlaceholder(parts);
+				const regularPlaceholder = defaultStrategy.getPlaceholder(parts) as string;
+				expect(regularPlaceholder).toBeTypeOf("string");
 				const oneUnderscore = defaultStrategy.getPlaceholder([
 					{ text: regularPlaceholder, start: 0, end: regularPlaceholder.length },
-				]);
+				]) as string;
+				expect(oneUnderscore).toBeTypeOf("string");
 
 				expect(oneUnderscore).not.toEqual(regularPlaceholder);
 				expect(oneUnderscore.includes("_")).toEqual(true);
@@ -53,7 +55,8 @@ describe("strategy", () => {
 			});
 
 			it("should return a value that is preserved by html-minifier when splitting", async () => {
-				const placeholder = defaultStrategy.getPlaceholder(parts);
+				const placeholder = defaultStrategy.getPlaceholder(parts) as string;
+				expect(placeholder).toBeTypeOf("string");
 				const minHtml = await defaultStrategy.minifyHTML(
 					`
           <style>

--- a/packages/rollup-plugin-minify-template-literals/package.json
+++ b/packages/rollup-plugin-minify-template-literals/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.1.4",
-    "minify-literals": "^1.0.0"
+    "minify-literals": "workspace:^*"
   },
   "devDependencies": {
     "rollup": "^4.34.9"


### PR DESCRIPTION
getPlaceholder now supports "strict mode" (return `string[]`), whereas it originally return `string` ("loose mode"). 
This better supports CSSminify.  
The following CSS-Template-Literals syntax patterns are supported: 
```
1. selector
${selector} {
}

2. key
selector {
  ${key}: value;
}

3. rule
[selector {}]
${rule}
[selector {}]

4. number-literal
selector{
  key: ${param}px;
}

5. value
selector {
  key: ${value};
  key: ${value}
}

6. param
selector{
  key: fun(${param}[, ${param}]);
}
```

**eg:**

```html
css`:host{
  ${"width"}: ${10}px;
}`;
css`:host{
  ${"width"}: calc(${10}px + ${"var(--data)"});
}`;
```